### PR TITLE
GPII-3927: Changed the tab IDs to something nicer

### DIFF
--- a/dataBlocks/officeRibbon/Word Basics+Essentials+StandardSet.xml
+++ b/dataBlocks/officeRibbon/Word Basics+Essentials+StandardSet.xml
@@ -21,7 +21,7 @@
       </mso:sharedControls>
     </mso:qat>
     <mso:tabs>
-      <mso:tab id="mso_c1.EDC33" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.basics" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c2.EDC33" label="                                                                                                                                                                            .                                 ." autoScale="true">
           <mso:control idQ="mso:FileNewDefault" visible="true"/>
           <mso:control idQ="mso:FileSave" visible="true"/>
@@ -50,7 +50,7 @@
           <mso:control idQ="mso:ToggleLearningTools" visible="true"/>
         </mso:group>
       </mso:tab>
-      <mso:tab id="mso_c22.1B75B9" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.essentials" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c23.1B75B9" label="FILE         PRINT        FORMAT" autoScale="true">
           <mso:control idQ="mso:FileNewDialogClassic" label="New " visible="true"/>
           <mso:gallery idQ="mso:PageMarginsGallery" showInRibbon="false" visible="true"/>

--- a/dataBlocks/officeRibbon/Word Basics+StandardSet.xml
+++ b/dataBlocks/officeRibbon/Word Basics+StandardSet.xml
@@ -20,7 +20,7 @@
       </mso:sharedControls>
     </mso:qat>
     <mso:tabs>
-      <mso:tab id="mso_c1.EDC33" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.basics" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c2.EDC33" label="                                                                                                                                                                            .                                 ." autoScale="true">
           <mso:control idQ="mso:FileNewDefault" visible="true" />
           <mso:control idQ="mso:FileSave" visible="true" />
@@ -49,7 +49,7 @@
           <mso:control idQ="mso:ToggleLearningTools" visible="true" />
         </mso:group>
       </mso:tab>
-      <mso:tab id="mso_c22.1B75B9" visible="false" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.essentials" visible="false" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c23.1B75B9" label="FILE         PRINT        FORMAT" autoScale="true">
           <mso:control idQ="mso:FileNewDialogClassic" label="New " visible="true" />
           <mso:gallery idQ="mso:PageMarginsGallery" showInRibbon="false" visible="true" />

--- a/dataBlocks/officeRibbon/Word Essentials+StandardSet.xml
+++ b/dataBlocks/officeRibbon/Word Essentials+StandardSet.xml
@@ -20,7 +20,7 @@
       </mso:sharedControls>
     </mso:qat>
     <mso:tabs>
-      <mso:tab id="mso_c1.EDC33" visible="false" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.basics" visible="false" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c2.EDC33" label="                                                                                                                                                                            .                                 ." autoScale="true">
           <mso:control idQ="mso:FileNewDefault" visible="true" />
           <mso:control idQ="mso:FileSave" visible="true" />
@@ -49,7 +49,7 @@
           <mso:control idQ="mso:ToggleLearningTools" visible="true" />
         </mso:group>
       </mso:tab>
-      <mso:tab id="mso_c22.1B75B9" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.essentials" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c23.1B75B9" label="FILE         PRINT        FORMAT" autoScale="true">
           <mso:control idQ="mso:FileNewDialogClassic" label="New " visible="true" />
           <mso:gallery idQ="mso:PageMarginsGallery" showInRibbon="false" visible="true" />

--- a/dataBlocks/officeRibbon/Word StandardSet.xml
+++ b/dataBlocks/officeRibbon/Word StandardSet.xml
@@ -20,7 +20,7 @@
       </mso:sharedControls>
     </mso:qat>
     <mso:tabs>
-      <mso:tab id="mso_c1.EDC33" visible="false" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.basics" visible="false" label=" Basics (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c2.EDC33" label="                                                                                                                                                                            .                                 ." autoScale="true">
           <mso:control idQ="mso:FileNewDefault" visible="true" />
           <mso:control idQ="mso:FileSave" visible="true" />
@@ -49,7 +49,7 @@
           <mso:control idQ="mso:ToggleLearningTools" visible="true" />
         </mso:group>
       </mso:tab>
-      <mso:tab id="mso_c22.1B75B9" visible="false" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
+      <mso:tab id="morphic.essentials" visible="false" label="Essentials (Morphic)" insertBeforeQ="mso:TabBlogPost">
         <mso:group id="mso_c23.1B75B9" label="FILE         PRINT        FORMAT" autoScale="true">
           <mso:control idQ="mso:FileNewDialogClassic" label="New " visible="true" />
           <mso:gallery idQ="mso:PageMarginsGallery" showInRibbon="false" visible="true" />


### PR DESCRIPTION
This just gives the Morphic tabs a better ID so the same one can be re-used in other Office applications.

Required by https://github.com/GPII/windows/pull/267.